### PR TITLE
Change items distance from menu center

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ resources:
 | `tap_action`        | `map`     | **Optional** | Action to take on tap. See [action options](#action-options)              | `action: toggle-menu` |
 | `hold_action`       | `map`     | **Optional** | Action to take on hold. See [action options](#action-options)             | `none`                |
 | `double_tap_action` | `map`     | **Optional** | Action to take on double tap. See [action options](#action-options)       | `action: none`        |
-| theme               | `string`  | **Optional** | Card theme                                                                |
+| `theme`             | `string`  | **Optional** | Card theme                                                                |                       |
+| `items_offset`      | `number`  | **Optional** | Distance of items from menu center                                        | `0`                   |
 
 ## Item Options
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ resources:
 | `hold_action`       | `map`     | **Optional** | Action to take on hold. See [action options](#action-options)             | `none`                |
 | `double_tap_action` | `map`     | **Optional** | Action to take on double tap. See [action options](#action-options)       | `action: none`        |
 | `theme`             | `string`  | **Optional** | Card theme                                                                |                       |
-| `items_offset`      | `number`  | **Optional** | Distance of items from menu center                                        | `0`                   |
+| `items_offset`      | `number`  | **Optional** | Distance of items from menu center                                        | `35`                   |
 
 ## Item Options
 

--- a/src/radial-menu.ts
+++ b/src/radial-menu.ts
@@ -41,7 +41,7 @@ export class RadialMenu extends LitElement {
         action: 'none',
       },
       default_dismiss: true,
-      items_offset: 0,
+      items_offset: 35,
       ...config,
     };
 
@@ -81,15 +81,18 @@ export class RadialMenu extends LitElement {
       <nav class="circular-menu">
         <div class="circle">
           ${this._config.items.map((item, index) => {
+            const _items_offset = this._config?.items_offset ?? 35;
             const left = this._config
-              ? (50 - (35 + (this._config?.items_offset ?? 0)) * Math.cos(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)).toFixed(
-                  4,
-                ) + '%'
+              ? (
+                  50 -
+                  _items_offset * Math.cos(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)
+                ).toFixed(4) + '%'
               : '';
             const top = this._config
-              ? (50 + (35 + (this._config?.items_offset ?? 0)) * Math.sin(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)).toFixed(
-                  4,
-                ) + '%'
+              ? (
+                  50 +
+                  _items_offset * Math.sin(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)
+                ).toFixed(4) + '%'
               : '';
 
             if (item.card && item.element) {

--- a/src/radial-menu.ts
+++ b/src/radial-menu.ts
@@ -41,6 +41,7 @@ export class RadialMenu extends LitElement {
         action: 'none',
       },
       default_dismiss: true,
+      items_offset: 0,
       ...config,
     };
 
@@ -81,12 +82,12 @@ export class RadialMenu extends LitElement {
         <div class="circle">
           ${this._config.items.map((item, index) => {
             const left = this._config
-              ? (50 - 35 * Math.cos(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)).toFixed(
+              ? (50 - (35 + (this._config?.items_offset ?? 0)) * Math.cos(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)).toFixed(
                   4,
                 ) + '%'
               : '';
             const top = this._config
-              ? (50 + 35 * Math.sin(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)).toFixed(
+              ? (50 + (35 + (this._config?.items_offset ?? 0)) * Math.sin(-0.5 * Math.PI - 2 * (1 / this._config.items.length) * index * Math.PI)).toFixed(
                   4,
                 ) + '%'
               : '';

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface RadialMenuConfig {
   hold_action?: ActionConfig;
   items: RadialMenuItemConfig[];
   theme?: string;
+  items_offset?: number;
 }
 
 export interface RadialMenuItemConfig {


### PR DESCRIPTION
On a phone the pop-up icons appear too far from the center of the menu and couldn't find a way to easily change it. And it seemed like there is at least one other person with the same problem on the [forum](https://community.home-assistant.io/t/lovelace-radial-menu-element/111210/43).

Added a new `items_offset` optional config option to be able to change this distance:
![image](https://user-images.githubusercontent.com/17529955/158078965-f43ff715-6f9f-4f5c-9a05-a36f7266114e.png)
